### PR TITLE
fix: repoUrl should include a trailing slash

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "better-than-before": "1.0.0",
     "chai": "3.4.1",
     "chokidar-cli": "1.2.0",
-    "conventional-changelog-core": "1.0.1",
+    "conventional-changelog-core": "1.8.0",
     "coveralls": "2.11.15",
     "cross-env": "3.1.3",
     "cz-customizable": "4.0.0",

--- a/src/templates/commit.hbs
+++ b/src/templates/commit.hbs
@@ -16,7 +16,7 @@
     {{~/if~}}
     {{~@root.repository}}/
   {{~else}}
-    {{~@root.repoUrl}}
+    {{~@root.repoUrl}}/
   {{~/if~}}
   commits/{{~hash}}))
 {{~else}}

--- a/src/templates/header.hbs
+++ b/src/templates/header.hbs
@@ -14,7 +14,7 @@
     {{~/if~}}
     {{~@root.repository}}/
   {{~else}}
-    {{~@root.repoUrl}}
+    {{~@root.repoUrl}}/
   {{~/if~}}
   compare/diff?targetBranch=refs%2Ftags%2F{{previousTag}}&sourceBranch=refs%2Ftags%2F{{currentTag}})
 {{~else}}

--- a/test/fixtures/bitbucket-http-host.json
+++ b/test/fixtures/bitbucket-http-host.json
@@ -1,0 +1,4 @@
+{
+  "version": "v2.0.0",
+  "repository": "https://bitbucket.example.com/projects/EX/repos/example-repo"
+}

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -256,8 +256,8 @@ describe('angular preset', function() {
     }).on('error', done).pipe(through(function(chunk, enc, cb) {
       chunk = chunk.toString();
 
-      expect(chunk).to.include('/compare/');
-      expect(chunk).to.include('/commits/');
+      expect(chunk).to.include('https://bitbucket.example.com/projects/EX/repos/example-repo/compare/');
+      expect(chunk).to.include('https://bitbucket.example.com/projects/EX/repos/example-repo/commits/');
       expect(chunk).to.match(/some more features \(.*\)/);
 
       i++;

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -243,4 +243,28 @@ describe('angular preset', function() {
         done();
       }));
   });
+
+  it('should support directly utilizing http/https repository urls', function(done) {
+    preparing(8);
+    let i = 0;
+
+    conventionalChangelogCore({
+      config: preset,
+      pkg: {
+        path: __dirname + '/fixtures/bitbucket-http-host.json',
+      },
+    }).on('error', done).pipe(through(function(chunk, enc, cb) {
+      chunk = chunk.toString();
+
+      expect(chunk).to.include('/compare/');
+      expect(chunk).to.include('/commits/');
+      expect(chunk).to.match(/some more features \(.*\)/);
+
+      i++;
+      cb();
+    }, function() {
+      expect(i).to.equal(1);
+      done();
+    }));
+  });
 });


### PR DESCRIPTION
Adds a trailing slash when `repoUrl` is used.

closes #5 