### PR TITLE
fix(build): update bitbucket url schemes

### DIFF
--- a/src/templates/commit.hbs
+++ b/src/templates/commit.hbs
@@ -9,10 +9,10 @@
   ([{{hash}}](
   {{~#if @root.repository~}}
     {{~#if @root.host}}
-      {{~@root.host}}/projects/
+      {{~@root.host}}/
     {{~/if}}
     {{~#if @root.owner~}}
-      {{~@root.owner}}/repos/
+      {{~@root.owner}}/
     {{~/if~}}
     {{~@root.repository}}/
   {{~else}}
@@ -27,4 +27,3 @@
 {{~#if references~}}
   , closes {{#each references}}{{this.raw}}{{/each}}
 {{~/if}}
-

--- a/src/templates/header.hbs
+++ b/src/templates/header.hbs
@@ -7,16 +7,16 @@
   [{{version}}](
   {{~#if @root.repository~}}
     {{~#if @root.host}}
-      {{~@root.host}}/projects/
+      {{~@root.host}}/
     {{~/if}}
     {{~#if @root.owner~}}
-      {{~@root.owner}}/repos/
+      {{~@root.owner}}/
     {{~/if~}}
     {{~@root.repository}}/
   {{~else}}
     {{~@root.repoUrl}}/
   {{~/if~}}
-  compare/diff?targetBranch=refs%2Ftags%2F{{previousTag}}&sourceBranch=refs%2Ftags%2F{{currentTag}})
+  compare/{{previousTag}}%0D{{currentTag}}#diff)
 {{~else}}
   {{~version}}
 {{~/if}}

--- a/src/templates/header.hbs
+++ b/src/templates/header.hbs
@@ -16,7 +16,7 @@
   {{~else}}
     {{~@root.repoUrl}}/
   {{~/if~}}
-  compare/{{previousTag}}%0D{{currentTag}}#diff)
+  compare/{{currentTag}}%0D{{previousTag}}#diff)
 {{~else}}
   {{~version}}
 {{~/if}}

--- a/test/fixtures/bitbucket-http-host.json
+++ b/test/fixtures/bitbucket-http-host.json
@@ -1,4 +1,4 @@
 {
   "version": "v2.0.0",
-  "repository": "https://bitbucket.example.com/projects/EX/repos/example-repo"
+  "repository": "https://bitbucket.example.com/EX/example-repo"
 }

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -87,7 +87,7 @@ describe('angular preset', function() {
         expect(chunk).to.not.include('***:**');
         expect(chunk).to.not.include(': Not backward compatible.');
 
-        expect(chunk).to.match(/oops \(\[[0-9a-z]{7}\]\(http:\/\/any.bbucket.host:7999\/projects\/proj\/repos\/repo-name\/commits\/[0-9a-z]{7}\)\)/);      // commit hash is linked
+        expect(chunk).to.match(/oops \(\[[0-9a-z]{7}\]\(http:\/\/any.bbucket.host:7999\/proj\/repo-name\/commits\/[0-9a-z]{7}\)\)/);      // commit hash is linked
 
         done();
       }));
@@ -206,8 +206,8 @@ describe('angular preset', function() {
         expect(chunk).to.include('some more features');
         expect(chunk).to.not.include('BREAKING');
 
-        expect(chunk).to.include('http://any.bbucket.host:7999/projects/proj/repos/repo-name/compare/diff?targetBranch' +
-          '=refs%2Ftags%2Fv1.0.0&sourceBranch=refs%2Ftags%2Fv2.0.0');
+        expect(chunk).to.include('http://any.bbucket.host:7999/proj/repo-name/compare/' +
+          'v1.0.0%0Dv2.0.0#diff');
 
         i++;
         cb();
@@ -256,8 +256,8 @@ describe('angular preset', function() {
     }).on('error', done).pipe(through(function(chunk, enc, cb) {
       chunk = chunk.toString();
 
-      expect(chunk).to.include('https://bitbucket.example.com/projects/EX/repos/example-repo/compare/');
-      expect(chunk).to.include('https://bitbucket.example.com/projects/EX/repos/example-repo/commits/');
+      expect(chunk).to.include('https://bitbucket.example.com/EX/example-repo/compare/');
+      expect(chunk).to.include('https://bitbucket.example.com/EX/example-repo/commits/');
       expect(chunk).to.match(/some more features \(.*\)/);
 
       i++;

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -207,7 +207,7 @@ describe('angular preset', function() {
         expect(chunk).to.not.include('BREAKING');
 
         expect(chunk).to.include('http://any.bbucket.host:7999/proj/repo-name/compare/' +
-          'v1.0.0%0Dv2.0.0#diff');
+          'v2.0.0%0Dv1.0.0#diff');
 
         i++;
         cb();


### PR DESCRIPTION
This PR updates the URL scheme in the the templates to match the current Bitbucket spec. I know that Bitbucket has recently undergone a redesign and this is likely when they changed their scheme.

I didn't tag this commit as a feature because it doesn't feel like one, but if you feel it makes more sense to tag it with a major version in case the old scheme is still valid for some users, I'll be happy to update the PR.