### PR TITLE
Jira tasks and issues links

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ let writerOpts = {
     const issueUrl = context.packageData.bugs && context.packageData.bugs.url;
 
     if (typeof commit.subject === 'string') {
-      commit.subject = commit.subject.replace(/#([A-Z0-9\-]+)/g, function(_, issue) {
+      commit.subject = commit.subject.replace(/#([a-zA-Z0-9\-]+)/g, function(_, issue) {
         issues.push(issue);
         return formatIssue(issueUrl, issue);
       });

--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,8 @@ let parserOpts = {
   revertCorrespondence: ['header', 'hash'],
 };
 
-
 let writerOpts = {
-  transform: function(commit, writerOpts) {
+  transform: function(commit, context) {
     let discard = true;
     let issues = [];
 
@@ -58,19 +57,20 @@ let writerOpts = {
       commit.hash = commit.hash.substring(0, 7);
     }
 
+    const issueUrl = context.packageData.bugs && context.packageData.bugs.url;
+
     if (typeof commit.subject === 'string') {
-      // Add any issues that are referenced in the subject line and them to our local issues array, but don't format them as links
-      (commit.subject.match(/#([0-9]+)/g) || []).forEach((issue) => issues.push(issue));
+      commit.subject = commit.subject.replace(/#([A-Z0-9\-]+)/g, function(_, issue) {
+        issues.push(issue);
+        return formatIssue(issueUrl, issue);
+      });
     }
 
     // remove references that already appear in the subject
-    commit.references = commit.references.filter(function(reference) {
-      if (issues.indexOf(reference.issue) === -1) {
-        return true;
-      }
-
-      return false;
-    });
+    commit.references = commit.references
+    .filter((reference) => issues.indexOf(reference.issue) === -1)
+    .map((reference) => formatIssue(issueUrl, reference.issue))
+    .join(', ');
 
     return commit;
   },
@@ -98,3 +98,11 @@ module.exports = Q.all([
       writerOpts: writerOpts,
     };
   });
+
+function formatIssue(issueUrl, issue) {
+    if (issueUrl) {
+      return '[#' + issue + '](' + issueUrl + '/' + issue + ')';
+    } else {
+      return '#' + issue;
+    }
+}

--- a/src/templates/commit.hbs
+++ b/src/templates/commit.hbs
@@ -25,6 +25,6 @@
 
 {{~!-- commit references --}}
 {{~#if references~}}
-  , closes {{#each references}}{{this.raw}}{{/each}}
+  , closes {{references}}
 {{~/if}}
 

--- a/test/fixtures/bitbucket-bugs.json
+++ b/test/fixtures/bitbucket-bugs.json
@@ -1,0 +1,6 @@
+{
+	"version": "v2.0.0",
+	"bugs": {
+		"url": "https://jirasson.betsson.com/browse"
+	}
+}

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -49,6 +49,9 @@ betterThanBefore.setups([
     shell.exec('git tag v1.0.0');
     gitDummyCommit('feat: some more features');
   },
+  function() {
+    gitDummyCommit(['feat(foo): add thing', 'closes #1223 #OBG-23']);
+  },
 ]);
 
 describe('angular preset', function() {
@@ -110,7 +113,7 @@ describe('angular preset', function() {
       }));
   });
 
-  it('should NOT generate issue links when we don\'t we don\'t have a path', function(done) {
+  it('should NOT generate issue links when we don\'t have a path', function(done) {
     preparing(3);
 
     conventionalChangelogCore({
@@ -292,5 +295,28 @@ describe('angular preset', function() {
       expect(i).to.equal(1);
       done();
     }));
+  });
+
+  it('should render comma delimited issues reference in \'closes\' when having multiple references', function(done) {
+    preparing(9);
+
+    conventionalChangelogCore({
+      config: preset,
+      context: {
+        packageData: {
+        },
+      },
+      pkg: {
+        path: __dirname + '/fixtures/bitbucket-host.json',
+      },
+    })
+      .on('error', function(err) {
+        done(err);
+      })
+      .pipe(through(function(chunk) {
+        chunk = chunk.toString();
+        expect(chunk).to.include('closes #1223, #OBG-23');
+        done();
+      }));
   });
 });

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -27,6 +27,7 @@ betterThanBefore.setups([
   },
   function() {
     gitDummyCommit(['feat(awesome): addresses the issue brought up in #133']);
+    gitDummyCommit(['revert(ngOptions): bad commit', 'closes #24']);
   },
   function() {
     gitDummyCommit(['feat(awesome): fix #88']);
@@ -93,11 +94,31 @@ describe('angular preset', function() {
       }));
   });
 
-  it('should NOT generate issue links because we don\'t know the issue tracker URL on BitBucket', function(done) {
+  it('should generate issue links if it\'s present in package.json', function(done) {
     preparing(2);
 
     conventionalChangelogCore({
       config: preset,
+    })
+      .on('error', function(err) {
+        done(err);
+      })
+      .pipe(through(function(chunk) {
+        chunk = chunk.toString();
+        expect(chunk).to.include('in [#133](https://github.com/uglow/conventional-changelog-angular-bitbucket/issues/133)');
+        done();
+      }));
+  });
+
+  it('should NOT generate issue links when we don\'t we don\'t have a path', function(done) {
+    preparing(3);
+
+    conventionalChangelogCore({
+      config: preset,
+      context: {
+        packageData: {
+        },
+      },
       pkg: {
         path: __dirname + '/fixtures/bitbucket-host.json',
       },
@@ -117,13 +138,18 @@ describe('angular preset', function() {
 
     conventionalChangelogCore({
       config: preset,
+      context: {
+        packageData: {
+
+        },
+      },
     })
       .on('error', function(err) {
         done(err);
       })
       .pipe(through(function(chunk) {
         chunk = chunk.toString();
-        expect(chunk).to.include(' fix #88');
+        expect(chunk).to.include(' fix [#88]');
         expect(chunk).to.not.include('closes [#88](');
         done();
       }));


### PR DESCRIPTION
- Add support to Jira tasks as it can have tasks alphanumeric such as OBG-44
- Add support to link to jira by using the bugs section in package.json

