### PR TITLE
feat: add support to `conventional-changelog` v3 and `lerna` v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,13 +56,14 @@
   },
   "dependencies": {
     "compare-func": "1.3.1",
+    "conventional-changelog-angular": "5.0.1",
     "q": "1.4.1"
   },
   "devDependencies": {
     "better-than-before": "1.0.0",
     "chai": "3.4.1",
     "chokidar-cli": "1.2.0",
-    "conventional-changelog-core": "1.8.0",
+    "conventional-changelog-core": "3.1.0",
     "coveralls": "2.13.1",
     "cross-env": "3.1.4",
     "cz-customizable": "5.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+let conventionalChangelogAngularPromise = require('conventional-changelog-angular');
 let compareFunc = require('compare-func');
 let Q = require('q');
 let readFile = Q.denodeify(require('fs').readFile);
@@ -86,16 +87,22 @@ module.exports = Q.all([
   readFile(resolve(__dirname, 'templates/header.hbs'), 'utf-8'),
   readFile(resolve(__dirname, 'templates/commit.hbs'), 'utf-8'),
   readFile(resolve(__dirname, 'templates/footer.hbs'), 'utf-8'),
+  conventionalChangelogAngularPromise,
 ])
-  .spread(function(template, header, commit, footer) {
+  .spread(function(template, header, commit, footer, conventionalChangelogAngular) {
     writerOpts.mainTemplate = template;
     writerOpts.headerPartial = header;
     writerOpts.commitPartial = commit;
     writerOpts.footerPartial = footer;
 
     return {
+      recommendedBumpOpts: conventionalChangelogAngular.recommendedBumpOpts,
       parserOpts: parserOpts,
       writerOpts: writerOpts,
+      conventionalChangelog: {
+        parserOpts: parserOpts,
+        writerOpts: writerOpts,
+      },
     };
   });
 


### PR DESCRIPTION
Lerna 3 cannot be used with the latest version of this packages because the versioning will not be correct. When comparing the public api of `conventional-changelog-angular` v5 and `conventional-changelog-angular-bitbucket`, there are missing properties. This PR adds support for those missing properties.

**Note**: it seemed cleaner to depend on `conventional-changelog-angular` to expose the `recommendedBumpOpts` property rather than copy pasting that code from `convetional-changelog-angular (less duplication, more future proof and no need to write additional specs to verify that logic).

Testing it locally with `lerna` `v3.4.3`, with these changes, it works as expected.