### PR TITLE
feat: add support for standard git revert message format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1687,6 +1687,7 @@
       "resolved": "https://nexus.cd.auspost.com.au/nexus/content/groups/auspost-ddc-npmjs/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2700,9 +2701,9 @@
       }
     },
     "conventional-changelog-angular": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.1.tgz",
-      "integrity": "sha512-q4ylJ68fWZDdrFC9z4zKcf97HW6hp7Mo2YlqD4owfXhecFKy/PJCU/1oVFF4TqochchChqmZ0Vb0e0g8/MKNlA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.6.tgz",
+      "integrity": "sha512-QDEmLa+7qdhVIv8sFZfVxU1VSyVvnXPsxq8Vam49mKUcO1Z8VTLEJk9uI21uiJUsnmm0I4Hrsdc9TgkOQo9WSA==",
       "requires": {
         "compare-func": "^1.3.1",
         "q": "^1.5.1"
@@ -4821,7 +4822,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4842,12 +4844,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4862,17 +4866,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4989,7 +4996,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5001,6 +5009,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5015,6 +5024,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5022,12 +5032,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5046,6 +5058,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5126,7 +5139,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5138,6 +5152,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5223,7 +5238,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5259,6 +5275,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5278,6 +5295,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5321,12 +5339,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6977,7 +6997,8 @@
       "version": "1.0.1",
       "resolved": "https://nexus.cd.auspost.com.au/nexus/content/groups/auspost-ddc-npmjs/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -10745,6 +10766,7 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -11643,7 +11665,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "compare-func": "1.3.1",
-    "conventional-changelog-angular": "5.0.1",
+    "conventional-changelog-angular": "5.0.6",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ let parserOpts = {
     'subject',
   ],
   noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
-  revertPattern: /^revert:\s([\s\S]*?)\s*This reverts commit (\w*)\./,
+  revertPattern: /^(?:Revert|revert:)\s"?([\s\S]+?)"?\s*This reverts commit (\w*)\./i,
   revertCorrespondence: ['header', 'hash'],
 };
 
@@ -34,7 +34,7 @@ let writerOpts = {
       commit.type = 'Bug Fixes';
     } else if (commit.type === 'perf') {
       commit.type = 'Performance Improvements';
-    } else if (commit.type === 'revert') {
+    } else if (commit.type === 'revert' || commit.revert) {
       commit.type = 'Reverts';
     } else if (discard) {
       return;

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -53,6 +53,10 @@ betterThanBefore.setups([
   function() {
     gitDummyCommit(['feat(foo): add thing', 'closes #1223 #OBG-23']);
   },
+  function() {
+    gitDummyCommit(['Revert \\"feat: bad feature\\"', 'This reverts commit 12345.'], false);
+    gitDummyCommit(['revert: feat: custom revert format', 'This reverts commit 5678.']);
+  },
 ]);
 
 describe('angular preset', function() {
@@ -332,6 +336,24 @@ describe('angular preset', function() {
         chunk = chunk.toString();
         expect(chunk).to.include('closes [#1223](');
         expect(chunk).to.include('1223), [#OBG-23]');
+        done();
+      }));
+  });
+
+  it('should render revert commit using standard Git revert message convention', function(done) {
+    preparing(10);
+
+    conventionalChangelogCore({
+      config: preset,
+      // Default package data (this repo!)
+    })
+      .on('error', function(err) {
+        done(err);
+      })
+      .pipe(through(function(chunk) {
+        chunk = chunk.toString();
+        expect(chunk).to.include('feat: bad feature');
+        expect(chunk).to.include('feat: custom revert format');
         done();
       }));
   });


### PR DESCRIPTION
Conventional changelog for angular accepts both the standard revert
pattern as well as the original conventional commit pattern. This change
is to support both for this preset. The regex exactly matches what is in
conventional-changelog-angular